### PR TITLE
Fix indentation configuration

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "arrowParens": "avoid",
+  "semi": true,
+  "bracketSpacing": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "endOfLine": "lf",
+  "quoteProps": "consistent"
+}

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         },
         "Prettier-SQL.tabSizeOverride": {
           "type": "number",
-          "default": 4,
+          "default": 2,
           "minimum": 1,
           "markdownDescription": "Override for `tabSize` if `#Prettier-SQL.ignoreTabSettings#` is active"
         },

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         },
         "Prettier-SQL.ignoreTabSettings": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "Ignore user and workplace settings for `tabSize` and `insertSpaces` (uses `#Prettier-SQL.tabSizeOverride#` and `#Prettier-SQL.insertSpacesOverride#`)?"
         },
         "Prettier-SQL.tabSizeOverride": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,10 +46,10 @@ export function activate(context: vscode.ExtensionContext) {
   const formatProvider = (language: SqlLanguage) => ({
     provideDocumentFormattingEdits(
       document: vscode.TextDocument,
-      options: vscode.FormattingOptions
+      formattingOptions: vscode.FormattingOptions
     ): vscode.TextEdit[] {
       const settings = vscode.workspace.getConfiguration('Prettier-SQL');
-      const formatConfigs = getConfigs(settings, options, language);
+      const formatConfigs = getConfigs(settings, formattingOptions, language);
 
       // extract all lines from document
       const lines = [...new Array(document.lineCount)].map((_, i) => document.lineAt(i).text);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,15 +10,15 @@ import {
 } from 'sql-formatter';
 
 const getConfigs = (
-  settings: vscode.WorkspaceConfiguration,
+  extensionSettings: vscode.WorkspaceConfiguration,
   formattingOptions: vscode.FormattingOptions | { tabSize?: number; insertSpaces?: boolean },
   language: SqlLanguage
 ): Partial<FormatOptions> => {
-  const ignoreTabSettings = settings.get<boolean>('ignoreTabSettings');
+  const ignoreTabSettings = extensionSettings.get<boolean>('ignoreTabSettings');
   const { tabSize, insertSpaces } = ignoreTabSettings // override tab settings if ignoreTabSettings is true
     ? {
-        tabSize: settings.get<number>('tabSizeOverride'),
-        insertSpaces: settings.get<boolean>('insertSpacesOverride'),
+        tabSize: extensionSettings.get<number>('tabSizeOverride'),
+        insertSpaces: extensionSettings.get<boolean>('insertSpacesOverride'),
       }
     : formattingOptions;
 
@@ -26,19 +26,19 @@ const getConfigs = (
   return {
     language:
       language === 'sql' // override default SQL language mode if SQLFlavourOverride is set
-        ? settings.get<SqlLanguage>('SQLFlavourOverride') ?? 'sql'
+        ? extensionSettings.get<SqlLanguage>('SQLFlavourOverride') ?? 'sql'
         : language,
     tabWidth: tabSize,
     useTabs: !insertSpaces,
-    keywordCase: settings.get<KeywordCase>('keywordCase'),
-    indentStyle: settings.get<IndentStyle>('indentStyle'),
-    logicalOperatorNewline: settings.get<LogicalOperatorNewline>('logicalOperatorNewline'),
-    tabulateAlias: settings.get<boolean>('tabulateAlias'),
-    commaPosition: settings.get<CommaPosition>('commaPosition'),
-    expressionWidth: settings.get<number>('expressionWidth'),
-    linesBetweenQueries: settings.get<number>('linesBetweenQueries'),
-    denseOperators: settings.get<boolean>('denseOperators'),
-    newlineBeforeSemicolon: settings.get<boolean>('newlineBeforeSemicolon'),
+    keywordCase: extensionSettings.get<KeywordCase>('keywordCase'),
+    indentStyle: extensionSettings.get<IndentStyle>('indentStyle'),
+    logicalOperatorNewline: extensionSettings.get<LogicalOperatorNewline>('logicalOperatorNewline'),
+    tabulateAlias: extensionSettings.get<boolean>('tabulateAlias'),
+    commaPosition: extensionSettings.get<CommaPosition>('commaPosition'),
+    expressionWidth: extensionSettings.get<number>('expressionWidth'),
+    linesBetweenQueries: extensionSettings.get<number>('linesBetweenQueries'),
+    denseOperators: extensionSettings.get<boolean>('denseOperators'),
+    newlineBeforeSemicolon: extensionSettings.get<boolean>('newlineBeforeSemicolon'),
   };
 };
 
@@ -100,7 +100,7 @@ export function activate(context: vscode.ExtensionContext) {
       const documentLanguage = vscode.window.activeTextEditor?.document.languageId ?? 'sql';
       const formatterLanguage = languages[documentLanguage] ?? 'sql';
 
-      const settings = vscode.workspace.getConfiguration('Prettier-SQL');
+      const extensionSettings = vscode.workspace.getConfiguration('Prettier-SQL');
 
       // get tab settings from workspace
       const workspaceConfig = vscode.workspace.getConfiguration('editor');
@@ -109,7 +109,7 @@ export function activate(context: vscode.ExtensionContext) {
         insertSpaces: workspaceConfig.get<boolean>('insertSpaces'),
       };
 
-      const formatConfigs = getConfigs(settings, tabOptions, formatterLanguage);
+      const formatConfigs = getConfigs(extensionSettings, tabOptions, formatterLanguage);
 
       const editor = vscode.window.activeTextEditor;
       try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ const getConfigs = (
 const getIndentationConfig = (
   extensionSettings: vscode.WorkspaceConfiguration,
   formattingOptions: Partial<vscode.FormattingOptions>
-) => {
+): Partial<FormatOptions> => {
   // override tab settings if ignoreTabSettings is true
   if (extensionSettings.get<boolean>('ignoreTabSettings')) {
     return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,13 +6,14 @@ import {
   IndentStyle,
   CommaPosition,
   LogicalOperatorNewline,
+  FormatOptions,
 } from 'sql-formatter';
 
 const getConfigs = (
   settings: vscode.WorkspaceConfiguration,
   formattingOptions: vscode.FormattingOptions | { tabSize: number; insertSpaces: boolean },
   language: SqlLanguage
-) => {
+): Partial<FormatOptions> => {
   const ignoreTabSettings = settings.get<boolean>('ignoreTabSettings');
   const { tabSize, insertSpaces } = ignoreTabSettings // override tab settings if ignoreTabSettings is true
     ? {
@@ -20,15 +21,15 @@ const getConfigs = (
         insertSpaces: settings.get<boolean>('insertSpacesOverride')!,
       }
     : formattingOptions;
-  const indent = insertSpaces ? ' '.repeat(tabSize) : '\t';
 
   // build format configs from settings
-  const formatConfigs = {
+  return {
     language:
       language === 'sql' // override default SQL language mode if SQLFlavourOverride is set
         ? settings.get<SqlLanguage>('SQLFlavourOverride') ?? 'sql'
         : language,
-    indent,
+    tabWidth: tabSize,
+    useTabs: !insertSpaces,
     keywordCase: settings.get<KeywordCase>('keywordCase'),
     indentStyle: settings.get<IndentStyle>('indentStyle'),
     logicalOperatorNewline: settings.get<LogicalOperatorNewline>('logicalOperatorNewline'),
@@ -39,8 +40,6 @@ const getConfigs = (
     denseOperators: settings.get<boolean>('denseOperators'),
     newlineBeforeSemicolon: settings.get<boolean>('newlineBeforeSemicolon'),
   };
-
-  return formatConfigs;
 };
 
 export function activate(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,12 @@ export function activate(context: vscode.ExtensionContext) {
   const formatSelectionCommand = vscode.commands.registerCommand(
     'prettier-sql-vscode.format-selection',
     () => {
-      const documentLanguage = vscode.window.activeTextEditor?.document.languageId ?? 'sql';
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        return;
+      }
+
+      const documentLanguage = editor.document.languageId ?? 'sql';
       const formatterLanguage = languages[documentLanguage] ?? 'sql';
 
       const extensionSettings = vscode.workspace.getConfiguration('Prettier-SQL');
@@ -124,10 +129,9 @@ export function activate(context: vscode.ExtensionContext) {
         formatterLanguage
       );
 
-      const editor = vscode.window.activeTextEditor;
       try {
         // format and replace each selection
-        editor?.edit(editBuilder => {
+        editor.edit(editBuilder => {
           editor.selections.forEach(sel =>
             editBuilder.replace(sel, format(editor.document.getText(sel), formatConfigs))
           );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,10 +103,10 @@ export function activate(context: vscode.ExtensionContext) {
       const extensionSettings = vscode.workspace.getConfiguration('Prettier-SQL');
 
       // get tab settings from workspace
-      const workspaceConfig = vscode.workspace.getConfiguration('editor');
+      const editorSettings = vscode.workspace.getConfiguration('editor');
       const tabOptions = {
-        tabSize: workspaceConfig.get<number>('tabSize'),
-        insertSpaces: workspaceConfig.get<boolean>('insertSpaces'),
+        tabSize: editorSettings.get<number>('tabSize'),
+        insertSpaces: editorSettings.get<boolean>('insertSpaces'),
       };
 
       const formatConfigs = getConfigs(extensionSettings, tabOptions, formatterLanguage);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,14 @@ const getIndentationConfig = (
   }
 };
 
+const getFormattingOptionsFromEditorConfig = () => {
+  const editorSettings = vscode.workspace.getConfiguration('editor');
+  return {
+    tabSize: editorSettings.get<number>('tabSize'),
+    insertSpaces: editorSettings.get<boolean>('insertSpaces'),
+  };
+};
+
 export function activate(context: vscode.ExtensionContext) {
   const formatProvider = (language: SqlLanguage) => ({
     provideDocumentFormattingEdits(
@@ -110,14 +118,11 @@ export function activate(context: vscode.ExtensionContext) {
 
       const extensionSettings = vscode.workspace.getConfiguration('Prettier-SQL');
 
-      // get tab settings from workspace
-      const editorSettings = vscode.workspace.getConfiguration('editor');
-      const tabOptions = {
-        tabSize: editorSettings.get<number>('tabSize'),
-        insertSpaces: editorSettings.get<boolean>('insertSpaces'),
-      };
-
-      const formatConfigs = getConfigs(extensionSettings, tabOptions, formatterLanguage);
+      const formatConfigs = getConfigs(
+        extensionSettings,
+        getFormattingOptionsFromEditorConfig(),
+        formatterLanguage
+      );
 
       const editor = vscode.window.activeTextEditor;
       try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import {
 
 const getConfigs = (
   extensionSettings: vscode.WorkspaceConfiguration,
-  formattingOptions: Partial<vscode.FormattingOptions>,
+  formattingOptions: vscode.FormattingOptions,
   language: SqlLanguage
 ): Partial<FormatOptions> => {
   return {
@@ -34,7 +34,7 @@ const getConfigs = (
 
 const getIndentationConfig = (
   extensionSettings: vscode.WorkspaceConfiguration,
-  formattingOptions: Partial<vscode.FormattingOptions>
+  formattingOptions: vscode.FormattingOptions
 ): Partial<FormatOptions> => {
   // override tab settings if ignoreTabSettings is true
   if (extensionSettings.get<boolean>('ignoreTabSettings')) {
@@ -118,8 +118,8 @@ export function activate(context: vscode.ExtensionContext) {
       const formatConfigs = getConfigs(
         extensionSettings,
         {
-          // According to types, these editor.options properties can also be strings,
-          // but according to docs, the string value is only applicable when setting,
+          // According to types, these editor.options properties can also be strings or undefined,
+          // but according to docs, the string|undefined value is only applicable when setting,
           // so it should be safe to cast them.
           tabSize: editor.options.tabSize as number,
           insertSpaces: editor.options.insertSpaces as boolean,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,8 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
       document: vscode.TextDocument,
       formattingOptions: vscode.FormattingOptions
     ): vscode.TextEdit[] {
-      const settings = vscode.workspace.getConfiguration('Prettier-SQL');
-      const formatConfigs = getConfigs(settings, formattingOptions, language);
+      const extensionSettings = vscode.workspace.getConfiguration('Prettier-SQL');
+      const formatConfigs = getConfigs(extensionSettings, formattingOptions, language);
 
       // extract all lines from document
       const lines = [...new Array(document.lineCount)].map((_, i) => document.lineAt(i).text);
@@ -68,7 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
             document.positionAt(0),
             document.lineAt(document.lineCount - 1).range.end
           ),
-          text + (settings.get('trailingNewline') ? '\n' : '')
+          text + (extensionSettings.get('trailingNewline') ? '\n' : '')
         ),
       ];
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import {
 
 const getConfigs = (
   extensionSettings: vscode.WorkspaceConfiguration,
-  formattingOptions: { tabSize?: number; insertSpaces?: boolean },
+  formattingOptions: Partial<vscode.FormattingOptions>,
   language: SqlLanguage
 ): Partial<FormatOptions> => {
   return {
@@ -34,7 +34,7 @@ const getConfigs = (
 
 const getIndentationConfig = (
   extensionSettings: vscode.WorkspaceConfiguration,
-  formattingOptions: { tabSize?: number; insertSpaces?: boolean }
+  formattingOptions: Partial<vscode.FormattingOptions>
 ) => {
   // override tab settings if ignoreTabSettings is true
   if (extensionSettings.get<boolean>('ignoreTabSettings')) {
@@ -50,7 +50,7 @@ const getIndentationConfig = (
   }
 };
 
-const getFormattingOptionsFromEditorConfig = () => {
+const getFormattingOptionsFromEditorConfig = (): Partial<vscode.FormattingOptions> => {
   const editorSettings = vscode.workspace.getConfiguration('editor');
   return {
     tabSize: editorSettings.get<number>('tabSize'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,14 +50,6 @@ const getIndentationConfig = (
   }
 };
 
-const getFormattingOptionsFromEditorConfig = (): Partial<vscode.FormattingOptions> => {
-  const editorSettings = vscode.workspace.getConfiguration('editor');
-  return {
-    tabSize: editorSettings.get<number>('tabSize'),
-    insertSpaces: editorSettings.get<boolean>('insertSpaces'),
-  };
-};
-
 export function activate(context: vscode.ExtensionContext) {
   const formatProvider = (language: SqlLanguage) => ({
     provideDocumentFormattingEdits(
@@ -125,7 +117,13 @@ export function activate(context: vscode.ExtensionContext) {
 
       const formatConfigs = getConfigs(
         extensionSettings,
-        getFormattingOptionsFromEditorConfig(),
+        {
+          // According to types, these editor.options properties can also be strings,
+          // but according to docs, the string value is only applicable when setting,
+          // so it should be safe to cast them.
+          tabSize: editor.options.tabSize as number,
+          insertSpaces: editor.options.insertSpaces as boolean,
+        },
         formatterLanguage
       );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,14 +11,14 @@ import {
 
 const getConfigs = (
   settings: vscode.WorkspaceConfiguration,
-  formattingOptions: vscode.FormattingOptions | { tabSize: number; insertSpaces: boolean },
+  formattingOptions: vscode.FormattingOptions | { tabSize?: number; insertSpaces?: boolean },
   language: SqlLanguage
 ): Partial<FormatOptions> => {
   const ignoreTabSettings = settings.get<boolean>('ignoreTabSettings');
   const { tabSize, insertSpaces } = ignoreTabSettings // override tab settings if ignoreTabSettings is true
     ? {
-        tabSize: settings.get<number>('tabSizeOverride')!,
-        insertSpaces: settings.get<boolean>('insertSpacesOverride')!,
+        tabSize: settings.get<number>('tabSizeOverride'),
+        insertSpaces: settings.get<boolean>('insertSpacesOverride'),
       }
     : formattingOptions;
 
@@ -105,8 +105,8 @@ export function activate(context: vscode.ExtensionContext) {
       // get tab settings from workspace
       const workspaceConfig = vscode.workspace.getConfiguration('editor');
       const tabOptions = {
-        tabSize: workspaceConfig.get<number>('tabSize')!,
-        insertSpaces: workspaceConfig.get<boolean>('insertSpaces')!,
+        tabSize: workspaceConfig.get<number>('tabSize'),
+        insertSpaces: workspaceConfig.get<boolean>('insertSpaces'),
       };
 
       const formatConfigs = getConfigs(settings, tabOptions, formatterLanguage);


### PR DESCRIPTION
The extension used a long-outdated `indent` option. Replaced it with `tabWidth` and `useTabs` options.

Also changed the defaults:

- changed `tabSizeOverride` from `4` to `2`. So it aligns with SQL Formatter default. The previous versions of the extension have been stuck at the 2-space indentation (as the `indent` config had no effect).
- changed `ignoreTabSettings` to `false`, so vscode settings are used by default. This seems like a more sensible default, making it easier to change the tab size through editor (without having to wander inside the configs of this extension).

Performed several refactorings, just to make better sense of the code.

There's one bug still, which I haven't managed to figure out:

<del>When I change the indentation in current window (e.g. "Indent using spaces" -> "2") and run the command "Format Selection (Prettier SQL)", it doesn't use the newly configured indentation settings. However when I run "Format Document", it properly indents the code.</del>

<del>I tried to debug this and found that these incorrect values come from `vscode.workspace.getConfiguration('editor')`. My guess is that it's reading in the default editor configuration, not the active configuration of current window.</del>

Found a fix: Switched to `vscode.window.activeTextEditor.options` instead of `vscode.workspace.getConfiguration('editor')`.

Fixes https://github.com/sql-formatter-org/sql-formatter/issues/289