### PR TITLE
Make paramTypes configurable from VSCode settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ Use the FORMATTING template if it is an issue related the formatting of the SQL,
 `Prettier-SQL.denseOperators`: Whether to strip whitespace around operators such as + or >=
 
 `Prettier-SQL.newlineBeforeSemicolon`: Whether to place semicolon on its own line or on previous line
+
+`Prettier-SQL.paramTypes`: Specifies parameter placeholders types to support

--- a/package.json
+++ b/package.json
@@ -230,6 +230,10 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Whether to place semicolon on its own line or on previous line"
+        },
+        "Prettier-SQL.paramTypes": {
+          "type": "object",
+          "markdownDescription": "Specifies parameter placeholders types to support."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,9 @@ import {
   CommaPosition,
   LogicalOperatorNewline,
   FormatOptionsWithLanguage,
+  FormatOptions
 } from 'sql-formatter';
+import { ParamTypes } from 'sql-formatter/lib/src/lexer/TokenizerOptions';
 
 const getConfigs = (
   extensionSettings: vscode.WorkspaceConfiguration,
@@ -29,6 +31,7 @@ const getConfigs = (
     linesBetweenQueries: extensionSettings.get<number>('linesBetweenQueries'),
     denseOperators: extensionSettings.get<boolean>('denseOperators'),
     newlineBeforeSemicolon: extensionSettings.get<boolean>('newlineBeforeSemicolon'),
+    paramTypes: extensionSettings.get<ParamTypes>('paramTypes')
   };
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ import {
   FormatOptionsWithLanguage,
   FormatOptions
 } from 'sql-formatter';
-import { ParamTypes } from 'sql-formatter/lib/src/lexer/TokenizerOptions';
+
+type ParamTypes = FormatOptions["paramTypes"];
 
 const getConfigs = (
   extensionSettings: vscode.WorkspaceConfiguration,


### PR DESCRIPTION
- Add `paramTypes` to the VSCode configuration properties
- The configuration has already been supported by the `sql-formatter` so we just need to enable to pass the parameter through the VSCode setting