### PR TITLE
Config by folder settings when in a workspace

### DIFF
--- a/src/SqlFormattingProvider.ts
+++ b/src/SqlFormattingProvider.ts
@@ -14,7 +14,7 @@ export class SqlFormattingProvider implements vscode.DocumentFormattingEditProvi
       return [
         vscode.TextEdit.replace(
           this.fullDocumentRange(document),
-          this.formatText(this.getAllText(document), formattingOptions),
+          this.formatText(this.getAllText(document), formattingOptions, document.uri),
         ),
       ];
     } catch (e) {
@@ -35,8 +35,8 @@ export class SqlFormattingProvider implements vscode.DocumentFormattingEditProvi
     );
   }
 
-  private formatText(text: string, formattingOptions: vscode.FormattingOptions) {
-    const extensionSettings = vscode.workspace.getConfiguration('SQL-Formatter-VSCode');
+  private formatText(text: string, formattingOptions: vscode.FormattingOptions, uri: vscode.Uri) {
+    const extensionSettings = vscode.workspace.getConfiguration('SQL-Formatter-VSCode', uri);
     const formatConfig = createConfig(extensionSettings, formattingOptions, this.language);
     return formatEditorText(text, formatConfig);
   }


### PR DESCRIPTION
When using a workspace in VS Code, the extension reads lint configuration only from `xxx.code-workspace` even though there are the folder settings at `.vscode/settings.json`. The reason is that we don't pass the document URI to get a configuration (`vscode.workspace.getConfiguration()`). This PR fixes the problem.

###### As-is

- Not in a workspace: Read config from `.vscode/settings.json` (expected)
- In a workspace without `.vscode/settings.json`: Read config from `xxx.code-workspace` (expected)
- In a workspace with `.vscode/settings.json`: Read config from `xxx.code-workspace` only (not expected)

###### To-be

- Not in a workspace: Read config from `.vscode/settings.json`
- In a workspace without `.vscode/settings.json`: Read config from `xxx.code-workspace`
- In a workspace with `.vscode/settings.json`: Read config from `.vscode/settings.json` (fixed)